### PR TITLE
Fix typo in French translation (#306)

### DIFF
--- a/addons/skin.plex/language/French/strings.po
+++ b/addons/skin.plex/language/French/strings.po
@@ -1313,7 +1313,7 @@ msgstr "Tous les épisodes"
 
 msgctxt "#32103"
 msgid "There is no description available for this "
-msgstr "Il n'y a pas de description pour ce"
+msgstr "Il n'y a pas de description pour cet "
 
 
 msgctxt "#32104"


### PR DESCRIPTION
* Modify: strings.po - Fix typo

Missing `t`

* Modify: strings.po - Fix typo

Add a missing space.